### PR TITLE
Create first draft of a manifest tool

### DIFF
--- a/api/log_entries.go
+++ b/api/log_entries.go
@@ -27,11 +27,16 @@ type FirmwareRelease struct {
 	// PlatformID identifies the hardware platform this release targets.
 	PlatformID string `json:"platform_id"`
 
-	// ArtifactSHA256 contains the SHA256 hashes of the named release artifacts.
-	ArtifactSHA256 map[string][]byte `json:"artifact_hashes"`
+	// Revision identifies the revision of this release.
+	// e.g. "v2021.05.03"
+	Revision string `json:"revision"`
 
-	// SourceURL is the location from which the source code used to produce this release can be downloaded.
-	SourceURL string `json:"source"`
+	// ArtifactSHA256 contains the SHA256 hashes of the named release artifacts.
+	ArtifactSHA256 map[string][]byte `json:"artifact_sha256"`
+
+	// SourceURL is the location from which an archive of the source code used to
+	// produce this release can be downloaded.
+	SourceURL string `json:"source_url"`
 
 	// SourceSHA256 is the SHA256 hash of the contents of the source file at the location
 	// pointed to by SourceURL.

--- a/cmd/create_release/README.md
+++ b/cmd/create_release/README.md
@@ -1,0 +1,44 @@
+create_release
+--------------
+
+This tool creates a JSON [api.FirmwareRelease](../../api/log_entries.go)
+structure using data from the GitHub API.
+
+e.g.:
+
+```bash
+$ go run ./cmd/create_release/ --logtostderr
+I0624 16:22:53.603475 2728324 main.go:83] Fetching release info...
+I0624 16:22:53.841686 2728324 main.go:103] Fetching and hashing source tarball...
+I0624 16:22:54.263937 2728324 main.go:110] Identifying commit hash associated with release...
+I0624 16:22:54.589783 2728324 main.go:129] Hashing release artifacts...
+I0624 16:22:56.691517 2728324 main.go:73] Create FirmwareMeta:
+{
+  "description": "v2021.05.03 (beta pre-release)",
+  "platform_id": "\u003cunset\u003e",
+  "revision": "v2021.05.03",
+  "artifact_sha256": {
+    "armory-drive.csf": "ihsnc+Y4xLsZvTxVoOojObuRYyp5IB7EluKljp+5aLQ=",
+    "armory-drive.imx": "GHf79fqYX3aXTOIiTdiuN2kT3aRvyqNs2mm63+XaOJc=",
+    "armory-drive.ota": "Y0bu1Aypdxy3UshH/v4bPrKNxb7rbFcqna+vbzqUerc=",
+    "armory-drive.sdp": "6jFHrxiS04Zu9eepCC0CC6YVr6Y3AB51ElNaJzhmCQQ=",
+    "armory-drive.sig": "iiZM1po/bVNqChfv5kLp+kNerYKYkgf8tZetNUeZ1tM=",
+    "armory-drive.srk": "NvUBxl9CZYe2al+G072gO+sFzZrWwx0F1iH0FUoDakM="
+  },
+  "source_url": "https://api.github.com/repos/f-secure-foundry/armory-drive/tarball/v2021.05.03",
+  "source_sha256": "YJjQfKIS7KTXc6ItugSSvmY5eKdboIR+oCOHM9QgzVA=",
+  "tool_chain": "tamago1.16.3",
+  "build_args": {
+    "REV": "5368a786cd492b025e86c6acc461f12d2d149923"
+  }
+}
+```
+
+Rate limits
+===========
+
+GitHub has a fairly low limit on the number of unauthenticated API requests any
+given IP address can make, if you hit these you can create a GitHub
+personal access token in your [account settings](https://github.com/settings/tokens)
+and copy it into an environment veriable called `GITHUB_TOKEN` which will
+substantially increase the limits.

--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -34,10 +34,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// TokenENV is the name of an environment variable to check for a github personal auth token.
+// If you're hitting GitHub API rate limits, setting this will raise the limits.
+const TokenENV = "GITHUB_TOKEN"
+
 var (
 	repo             = flag.String("repo", "f-secure-foundry/armory-drive", "GitHub repo to search for releases")
 	tag              = flag.String("tag", "", "Release tag to fetch, if unset, uses latest release")
-	includeArtifacts = flag.String("include_artifacts", "armory-drive\\.*", "Regex to specify release artifacts to include in manifest")
+	includeArtifacts = flag.String("include_artifacts", `armory-drive\.[[:alnum:]]*$`, "Regex to specify release artifacts to include in manifest")
 )
 
 func main() {
@@ -123,7 +127,7 @@ func getRelease(ctx context.Context, c *github.Client, owner, repo, tag string) 
 			glog.V(1).Infof("Ignoring artifact %q", *a.Name)
 			continue
 		}
-		h, err := hashRemote(*a.URL)
+		h, err := hashRemote(*a.BrowserDownloadURL)
 		if err != nil {
 			return api.FirmwareRelease{}, fmt.Errorf("failed to hash asset at %q: %q", *a.BrowserDownloadURL, err)
 		}

--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -1,0 +1,197 @@
+// Copyright 2021 The Project Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// create_release is a tool to create a release manifest from a GitHub release.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/f-secure-foundry/armory-drive-log/api"
+	"github.com/golang/glog"
+	"github.com/google/go-github/v35/github"
+	"golang.org/x/oauth2"
+)
+
+var (
+	repo             = flag.String("repo", "f-secure-foundry/armory-drive", "GitHub repo to search for releases")
+	tag              = flag.String("tag", "", "Release tag to fetch, if unset, uses latest release")
+	includeArtifacts = flag.String("include_artifacts", "armory-drive\\.*", "Regex to specify release artifacts to include in manifest")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+
+	owner, repo, err := splitRepoFlag(*repo)
+	if err != nil {
+		glog.Exitf("Couldn't parse repo: %q", err)
+	}
+
+	c := github.NewClient(getHTTPClient(ctx))
+
+	r, err := getRelease(ctx, c, owner, repo, *tag)
+	if err != nil {
+		glog.Exitf("Failed to fetch releases: %q", err)
+	}
+
+	glog.Info("Created FirmwareRelease struct:")
+
+	// Write struct to stdout in case we're being piped.
+	pp, _ := json.MarshalIndent(r, "", "  ")
+	fmt.Println(string(pp))
+}
+
+// getRelease uses the GitHub API to retrieve information about the tagged release, and uses it
+// to populate a FirmwareRelease struct.
+func getRelease(ctx context.Context, c *github.Client, owner, repo, tag string) (api.FirmwareRelease, error) {
+	artifactMatcher, err := regexp.Compile(*includeArtifacts)
+	if err != nil {
+		return api.FirmwareRelease{}, fmt.Errorf("invalid regex passed to --include_artifacts: %q", err)
+	}
+
+	glog.Info("Fetching release info...")
+	// First grab the release info from GitHub
+	var rel *github.RepositoryRelease
+	if tag == "" {
+		rel, _, err = c.Repositories.GetLatestRelease(ctx, owner, repo)
+		if err != nil {
+			return api.FirmwareRelease{}, fmt.Errorf("failed to get latest release: %q", err)
+		}
+	} else {
+		rel, _, err = c.Repositories.GetReleaseByTag(ctx, owner, repo, tag)
+		if err != nil {
+			return api.FirmwareRelease{}, fmt.Errorf("failed to get release with tag %q: %q", tag, err)
+		}
+	}
+	if glog.V(1) {
+		pp, _ := json.MarshalIndent(rel, "", "  ")
+		glog.V(1).Infof("Found release:\n%s", pp)
+	}
+
+	// Hash the release's source tarball
+	glog.Info("Fetching and hashing source tarball...")
+	sourceURL := *rel.TarballURL
+	sourceHash, err := hashRemote(sourceURL)
+	if err != nil {
+		return api.FirmwareRelease{}, fmt.Errorf("failed to hash release source: %q", err)
+	}
+
+	glog.Info("Identifying commit hash associated with release...")
+	releaseCommitSHA, err := fetchReleaseCommit(ctx, c, owner, repo, *rel.TagName)
+
+	// Finally, build the FirmwareRelease structure
+	fr := api.FirmwareRelease{
+		Description: *rel.Name,
+		// TODO(al): This needs to be in the release data somewhere
+		PlatformID:   "<unset>",
+		Revision:     *rel.TagName,
+		SourceURL:    sourceURL,
+		SourceSHA256: sourceHash,
+		// TODO(al): This needs to be in the release data somewhere
+		ToolChain: "tamago1.16.3",
+		BuildArgs: map[string]string{
+			"REV": releaseCommitSHA,
+		},
+		ArtifactSHA256: make(map[string][]byte),
+	}
+
+	glog.Info("Hashing release artifacts...")
+	for _, a := range rel.Assets {
+		if !artifactMatcher.MatchString(*a.Name) {
+			glog.V(1).Infof("Ignoring artifact %q", *a.Name)
+			continue
+		}
+		h, err := hashRemote(*a.URL)
+		if err != nil {
+			return api.FirmwareRelease{}, fmt.Errorf("failed to hash asset at %q: %q", *a.BrowserDownloadURL, err)
+		}
+		fr.ArtifactSHA256[*a.Name] = h
+
+	}
+	return fr, err
+}
+
+// splitRepoFlag separates a short owner/repo string into its consistuent parts.
+func splitRepoFlag(repo string) (string, string, error) {
+	if repo == "" {
+		return "", "", errors.New("--repo must not be empty")
+	}
+	r := strings.Split(repo, "/")
+	if len(r) != 2 {
+		return "", "", errors.New("--repo should be of the form 'owner/repo'")
+	}
+	return r[0], r[1], nil
+}
+
+// fetchReleaseCommit returns the git SHA associated with the provided tag.
+func fetchReleaseCommit(ctx context.Context, c *github.Client, owner, repo, tag string) (string, error) {
+	// Look up the commit hash associated with the release tag
+	tagRef := fmt.Sprintf("tags/%s", tag)
+	ref, _, err := c.Git.GetRef(ctx, owner, repo, tagRef)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up ref %q: %q ", tagRef, err)
+	}
+	relTag, _, err := c.Git.GetTag(ctx, owner, repo, *ref.Object.SHA)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up tag SHA %q: %q ", *ref.Object.SHA, err)
+	}
+	if glog.V(1) {
+		pp, _ := json.MarshalIndent(relTag, "", "  ")
+		glog.V(1).Infof("Found ref:\n%s", pp)
+	}
+	return *relTag.Object.SHA, nil
+}
+
+// hashRemote returns the SHA256 of the contents of the resource pointed to by url.
+func hashRemote(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %q: %q", url, err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got non-200 HTTP status when fetching %q: %s", url, resp.Status)
+	}
+	defer resp.Body.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, resp.Body); err != nil {
+		return nil, fmt.Errorf("failed to hash content: %q", err)
+	}
+	return h.Sum(nil), nil
+}
+
+// getHTTPClient returns a client for accessing the github API.
+//
+// If the GITHUB_TOKEN env variable is set, then this client will use its contents
+// as an OAUTH token for all requests to the github API (this greatly increases
+// the API rate limits.
+func getHTTPClient(ctx context.Context) *http.Client {
+	tok := os.Getenv(TokenENV)
+	if tok != "" {
+		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tok})
+		return oauth2.NewClient(ctx, ts)
+	}
+	return http.DefaultClient
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/f-secure-foundry/armory-drive-log
+
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/f-secure-foundry/armory-drive-log
 
 go 1.16
+
+require (
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
+	github.com/google/go-github/v35 v35.3.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/f-secure-foundry/armory-drive-log
 go 1.16
 
 require (
-	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
-	github.com/google/go-github/v35 v35.3.0 // indirect
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
+	github.com/google/go-github/v35 v35.3.0
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/golang/glog v0.0.0-20210429001901-424d2337a529 h1:2voWjNECnrZRbfwXxHB1/j8wa6xdKn85B5NzgVL/pTU=
+github.com/golang/glog v0.0.0-20210429001901-424d2337a529/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
+github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529 h1:2voWjNECnrZRbfwXxHB1/j8wa6xdKn85B5NzgVL/pTU=
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
@@ -8,9 +9,12 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
This tool interrogates the GitHub API to create a `FirmwareRelease` structure.

Eventually it's intended to be used as part of the process of a GitHub action on the firmware repo, triggered by the creation of a new release, to insert a new entry into this log.