### PR TITLE
pull in log actions

### DIFF
--- a/.github/workflows/leaves_pr.yaml
+++ b/.github/workflows/leaves_pr.yaml
@@ -1,0 +1,15 @@
+on: [pull_request]
+
+jobs:
+  leaf_validator_job:
+    runs-on: ubuntu-latest
+    name: Validate pending leaves
+    steps:
+    - uses: actions/checkout@v2
+      with:
+         fetch-depth: 0
+    - name: Leaf validator step
+      id: leaf_validator
+      uses: google/trillian-examples/serverless/deploy/github/leaf_validator@master
+      with:
+        log_dir: './log'

--- a/.github/workflows/push_to_master.yaml
+++ b/.github/workflows/push_to_master.yaml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sequence_and_integrate_job:
+    runs-on: ubuntu-latest
+    name: Sequence and integrate pending log entries
+    steps:
+    - uses: actions/checkout@v2
+    - name: Sequence and integrate step
+      id: sequence_and_integrate
+      uses: google/trillian-examples/serverless/deploy/github/sequence_and_integrate@master
+      with:
+        log_dir: './log'
+      env:
+        SERVERLESS_LOG_PRIVATE_KEY: ${{ secrets.SERVERLESS_LOG_PRIVATE_KEY }}
+        SERVERLESS_LOG_PUBLIC_KEY: ${{ secrets.SERVERLESS_LOG_PUBLIC_KEY }}
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_user_name: Serverless Bot
+        commit_user_email: actions@github.com
+        commit_author: Serverless Bot <actions@github.com>
+        commit_message: Automatically sequence and integrate log


### PR DESCRIPTION
Pull in actions for appending AD firmware manifests to the log.
Taken from:
https://github.com/google/trillian-examples/tree/master/serverless/deploy/github