### PR TITLE
Small improvements for create_release tool

### DIFF
--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -76,6 +76,9 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to hash artifacts: %q", err)
 	}
+	if len(artifacts) == 0 {
+		glog.Exit("--artifacts matched ZERO files")
+	}
 	fr.ArtifactSHA256 = artifacts
 
 	pp, err := json.MarshalIndent(fr, "", "  ")

--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -41,6 +41,7 @@ var (
 	artifacts      = flag.String("artifacts", `armory-drive.*`, "Space separated list of globs specifying the release artifacts to include")
 	revisionTag    = flag.String("revision_tag", "", "The git tag name which identifies the firmware revision")
 	privateKeyFile = flag.String("private_key", "", "Path to file containing the private key used to sign the manifest")
+	output         = flag.String("output", "", "Path to write the output to, leave empty to write to stdout")
 )
 
 func main() {
@@ -86,7 +87,14 @@ func main() {
 		glog.Exitf("Failed to sign FirmwareRelease JSON: %q", err)
 	}
 	// Write struct to stdout in case we're being piped.
-	fmt.Println(string(s))
+	if *output == "" {
+		fmt.Println(string(s))
+	} else {
+		if err := os.WriteFile(*output, s, 0644); err != nil {
+			glog.Exitf("Failed to write output to %q: %v", *output, err)
+		}
+
+	}
 }
 
 // sign signs the passed in body using the Go sumdb's note format.

--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -53,7 +53,7 @@ func main() {
 	sourceURL := fmt.Sprintf("https://github.com/%s/tarball/%s", *repo, *revisionTag)
 	sourceHash, err := hashRemote(sourceURL)
 	if err != nil {
-		glog.Exitf("Failed to hash source tarball (%s): %q", sourceURL, err)
+		glog.Exitf("Failed to hash source tarball (%s): %v", sourceURL, err)
 	}
 
 	fr := api.FirmwareRelease{
@@ -74,7 +74,7 @@ func main() {
 	glog.Info("Hashing release artifacts...")
 	artifacts, err := hashArtifacts()
 	if err != nil {
-		glog.Exitf("Failed to hash artifacts: %q", err)
+		glog.Exitf("Failed to hash artifacts: %v", err)
 	}
 	if len(artifacts) == 0 {
 		glog.Exit("--artifacts matched ZERO files")
@@ -83,11 +83,11 @@ func main() {
 
 	pp, err := json.MarshalIndent(fr, "", "  ")
 	if err != nil {
-		glog.Exitf("Failed to marshal FirmwareRelease: %q", err)
+		glog.Exitf("Failed to marshal FirmwareRelease: %v", err)
 	}
 	s, err := sign(string(pp))
 	if err != nil {
-		glog.Exitf("Failed to sign FirmwareRelease JSON: %q", err)
+		glog.Exitf("Failed to sign FirmwareRelease JSON: %v", err)
 	}
 	// Write struct to stdout in case we're being piped.
 	if *output == "" {
@@ -109,11 +109,11 @@ func sign(body string) ([]byte, error) {
 
 	k, err := os.ReadFile(*privateKeyFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read private key file: %q", err)
+		return nil, fmt.Errorf("failed to read private key file: %v", err)
 	}
 	signer, err := note.NewSigner(string(k))
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialise key: %q", err)
+		return nil, fmt.Errorf("failed to initialise key: %v", err)
 	}
 
 	return note.Sign(&note.Note{Text: body}, signer)
@@ -164,7 +164,7 @@ func hashArtifacts() (map[string][]byte, error) {
 func hashRemote(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch %q: %q", url, err)
+		return nil, fmt.Errorf("failed to fetch %q: %v", url, err)
 	}
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("got non-200 HTTP status when fetching %q: %s", url, resp.Status)
@@ -185,7 +185,7 @@ func hashFile(path string) ([]byte, error) {
 func hash(r io.Reader) ([]byte, error) {
 	h := sha256.New()
 	if _, err := io.Copy(h, r); err != nil {
-		return nil, fmt.Errorf("failed to hash content: %q", err)
+		return nil, fmt.Errorf("failed to hash content: %v", err)
 	}
 	return h.Sum(nil), nil
 }


### PR DESCRIPTION
- Allow writing output to a file
- Abort if no artifacts match the glob(s)
- Fewer quotes in the errors printed out