### PR TITLE
Publish test public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-The current test serverless public key is:
-
-```
-armory-drive-log-test+a5aae457+AbDoiIsZgSk5H0v0LjKPKv5dAMb0IfB47tocFtGmyW44
-```

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,14 @@
+Public Keys
+-----------
+
+The release manifest **test** public key is:
+
+```
+armory-drive-test+e0b83da5+ARFd7yMO7VQgK/N+KWETnS5O6dSqcTmTzQUXgQhJVVG0
+```
+
+The FT log **test** public key is:
+
+```
+armory-drive-log-test+a5aae457+AbDoiIsZgSk5H0v0LjKPKv5dAMb0IfB47tocFtGmyW44
+```

--- a/keys/armory-drive-log-test.pub
+++ b/keys/armory-drive-log-test.pub
@@ -1,0 +1,1 @@
+armory-drive-log-test+a5aae457+AbDoiIsZgSk5H0v0LjKPKv5dAMb0IfB47tocFtGmyW44

--- a/keys/armory-drive-test.pub
+++ b/keys/armory-drive-test.pub
@@ -1,0 +1,1 @@
+armory-drive-test+e0b83da5+ARFd7yMO7VQgK/N+KWETnS5O6dSqcTmTzQUXgQhJVVG0


### PR DESCRIPTION
Publish the pub keys, this way the GH actions can access the pub keys directly without passing through GH secrets.