### PR TITLE
Interpret 404 as ErrNotExist

### DIFF
--- a/cmd/create_proofbundle/main.go
+++ b/cmd/create_proofbundle/main.go
@@ -195,5 +195,13 @@ func readHTTP(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case 200:
+		return ioutil.ReadAll(resp.Body)
+	case 404:
+		return nil, os.ErrNotExist
+	default:
+		return nil, fmt.Errorf("failed to fetch url: %s", resp.Status)
+	}
 }


### PR DESCRIPTION
Fetcher implementations must return an `os.ErrNotExist` if the resource they've been asked to retrieve doesn't exist, otherwise the serverless client code doesn't know what's going on.