### PR TITLE
Added a monitor that follows the log, printing out verified releases.

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -1,0 +1,218 @@
+// Copyright 2021 The Project Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// monitor starts a long-running process that will continually follow a log
+// for new checkpoints. All checkpoints are checked for consistency, and all
+// leaves in the tree will be downloaded, verified, and the release info
+// printed to the program's log (via `glog.Info`).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/f-secure-foundry/armory-drive-log/api"
+	"github.com/golang/glog"
+	"github.com/google/trillian-examples/serverless/client"
+	"github.com/google/trillian/merkle/rfc6962/hasher"
+	"golang.org/x/mod/sumdb/note"
+)
+
+var (
+	pollInterval  = flag.Duration("poll_interval", 1*time.Minute, "The interval at which the log will be polled for new data")
+	stateFile     = flag.String("state_file", "", "File path for where checkpoints should be stored")
+	logURL        = flag.String("log_url", "https://raw.githubusercontent.com/f-secure-foundry/armory-drive-log/master/log/", "URL identifying the location of the log")
+	logPubKey     = flag.String("log_pubkey", "armory-drive-log-test+a5aae457+AbDoiIsZgSk5H0v0LjKPKv5dAMb0IfB47tocFtGmyW44", "The log's public key")
+	releasePubKey = flag.String("release_pubkey", "armory-drive-test+e0b83da5+ARFd7yMO7VQgK/N+KWETnS5O6dSqcTmTzQUXgQhJVVG0", "The release signer's public key")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+
+	st, isNew, err := stateTrackerFromFlags()
+	if err != nil {
+		glog.Exitf("Failed to create new LogStateTracker: %v", err)
+	}
+
+	var releaseVerifiers note.Verifiers
+	if v, err := note.NewVerifier(*releasePubKey); err != nil {
+		glog.Exitf("Failed to construct release note verifier: %v", err)
+	} else {
+		releaseVerifiers = note.VerifierList(v)
+	}
+
+	monitor := Monitor{
+		st:               st,
+		stateFile:        *stateFile,
+		releaseVerifiers: releaseVerifiers,
+		handler: func(i uint64, r api.FirmwareRelease) error {
+			glog.Infof("%d: Release version %q available at %s", i, r.Revision, r.SourceURL)
+			return nil
+		},
+	}
+
+	if isNew {
+		// This monitor has no memory of running before, so let's catch up with the log.
+		if err := monitor.From(0); err != nil {
+			glog.Exitf("monitor.From(%d): %v", 0, err)
+		}
+	}
+
+	// We've processed all leaves committed to by the tracker's checkpoint, and now we enter polling mode.
+	ticker := time.NewTicker(*pollInterval)
+	defer ticker.Stop()
+	for {
+		lastHead := st.LatestConsistent.Size
+		if err := st.Update(); err != nil {
+			glog.Exitf("Failed to update checkpoint: %q", err)
+		}
+		if st.LatestConsistent.Size > lastHead {
+			glog.V(1).Infof("Found new checkpoint for tree size %d, fetching new leaves", st.LatestConsistent.Size)
+			if err := monitor.From(lastHead); err != nil {
+				glog.Exitf("monitor.From(%d): %v", lastHead, err)
+			}
+		} else {
+			glog.V(2).Infof("Polling: no new data found; tree size is still %d", st.LatestConsistent.Size)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Go around the loop again.
+		}
+	}
+}
+
+// Monitor verifiably checks inclusion of all leaves in a range, and then passes the
+// parsed FirmwareRelease to a handler.
+type Monitor struct {
+	st               client.LogStateTracker
+	stateFile        string
+	releaseVerifiers note.Verifiers
+	handler          func(uint64, api.FirmwareRelease) error
+}
+
+// From checks the leaves from `start` up to the checkpoint from the state tracker.
+// Upon reaching the end of the leaves, the checkpoint is persisted in the state file.
+func (m *Monitor) From(start uint64) error {
+	fromCP := m.st.LatestConsistent
+	pb, err := client.NewProofBuilder(fromCP, m.st.Hasher.HashChildren, m.st.Fetcher)
+
+	if err != nil {
+		return fmt.Errorf("failed to construct proof builder: %v", err)
+	}
+	for i := start; i < fromCP.Size; i++ {
+		rawLeaf, err := client.GetLeaf(m.st.Fetcher, i)
+		if err != nil {
+			return fmt.Errorf("failed to get leaf at index %d: %v", i, err)
+		}
+		hash := m.st.Hasher.HashLeaf(rawLeaf)
+		ip, err := pb.InclusionProof(i)
+		if err != nil {
+			return fmt.Errorf("failed to get inclusion proof for index %d: %v", i, err)
+		}
+		wantRoot, err := m.st.Verifier.RootFromInclusionProof(int64(i), int64(fromCP.Size), ip, hash)
+		if err != nil {
+			return fmt.Errorf("failed to calculate root from inclusion proof at index %d: %v", i, err)
+		}
+		if !bytes.Equal(wantRoot, fromCP.Hash) {
+			return fmt.Errorf("failed to verify inclusion proof for leaf %d.\ncheckpoint: %x\ncalculated: %x",
+				i, fromCP.Hash, wantRoot)
+		}
+
+		// XXX: this is unexpected. the hash is over the data with the trailing newline but we need to remove it
+		// in order to make this data into a valid note.
+		trimmedLeaf := strings.TrimSuffix(string(rawLeaf), "\n")
+		releaseNote, err := note.Open([]byte(trimmedLeaf), m.releaseVerifiers)
+		if err != nil {
+			return fmt.Errorf("failed to open leaf note at index %d: %v", i, err)
+		}
+
+		var release api.FirmwareRelease
+		if err := json.Unmarshal([]byte(releaseNote.Text), &release); err != nil {
+			return fmt.Errorf("failed to unmarshal release at index %d: %w", i, err)
+		}
+		if err := m.handler(i, release); err != nil {
+			return fmt.Errorf("handler(): %w", err)
+		}
+	}
+	return ioutil.WriteFile(m.stateFile, m.st.LatestConsistentRaw, 0644)
+}
+
+// stateTrackerFromFlags constructs a state tracker based on the flags provided to the main invocation.
+// The checkpoint returned will be the checkpoint representing this monitor's view of the log history.
+// A boolean is returned that is true iff the checkpoint was fetched from the log to initialize state.
+func stateTrackerFromFlags() (client.LogStateTracker, bool, error) {
+	if len(*stateFile) == 0 {
+		glog.Exit("--state_file required")
+	}
+
+	state, err := ioutil.ReadFile(*stateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			glog.Infof("State file %q missing. Will trust first checkpoint received from log.", *stateFile)
+		} else {
+			return client.LogStateTracker{}, false, fmt.Errorf("could not read state file %q: %w", *stateFile, err)
+		}
+	}
+
+	root, err := url.Parse(*logURL)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("failed to parse log URL %q: %w", *logURL, err)
+	}
+	f, err := newFetcher(root)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("failed to create fetcher: %v", err)
+	}
+
+	lSigV, err := note.NewVerifier(*logPubKey)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("unable to create new log signature verifier: %w", err)
+	}
+
+	lst, err := client.NewLogStateTracker(f, hasher.DefaultHasher, state, lSigV)
+	return lst, state == nil, err
+}
+
+// newFetcher creates a Fetcher for the log at the given root location.
+func newFetcher(root *url.URL) (client.Fetcher, error) {
+	if s := root.Scheme; s != "http" && s != "https" {
+		return nil, fmt.Errorf("unsupported URL scheme %s", s)
+	}
+
+	return func(p string) ([]byte, error) {
+		u, err := root.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.Get(u.String())
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		return ioutil.ReadAll(resp.Body)
+	}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/google/go-cmp v0.5.6
 	github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb
-	github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55
+	github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c
 	golang.org/x/mod v0.4.2
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/google/go-cmp v0.5.6
 	github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb
-	github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c
+	github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55
 	golang.org/x/mod v0.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -326,14 +326,8 @@ github.com/google/trillian v1.3.14-0.20210409160123-c5ea3abd4a41/go.mod h1:1dPv0
 github.com/google/trillian v1.3.14-0.20210511103300-67b5f349eefa/go.mod h1:s4jO3Ai4NSvxucdvqUHON0bCqJyoya32eNw6XJwsmNc=
 github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb h1:yeHtIX6OICHMk4i8+mzZeYLcGXD5WvT4lfhhF/1MAaI=
 github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb/go.mod h1:Q959//o0gl8oMt92EQCmgoG1bgLmptrBT7ArV281XW0=
-github.com/google/trillian-examples v0.0.0-20210629140754-b2a641c1329a h1:v7vBKrza5hbRXfm4q4Bpf3fdk9da0rg85PXTzRDZ1vA=
-github.com/google/trillian-examples v0.0.0-20210629140754-b2a641c1329a/go.mod h1:Xm6ZXezVUpfDMxjSr2DxdhlNdoGvfkLEQrU7fHJd9uc=
-github.com/google/trillian-examples v0.0.0-20210629160522-bd61494bffc8 h1:28z3CPd31x/vW5BE//dDADpRlqFv083bqiZNKJ7qnMc=
-github.com/google/trillian-examples v0.0.0-20210629160522-bd61494bffc8/go.mod h1:Xm6ZXezVUpfDMxjSr2DxdhlNdoGvfkLEQrU7fHJd9uc=
-github.com/google/trillian-examples v0.0.0-20210630160956-ae33f63e85a0 h1:qdJBQmLTFaSCAivQkZdlnQS/GOypk+OHs5lD/WXLxYk=
-github.com/google/trillian-examples v0.0.0-20210630160956-ae33f63e85a0/go.mod h1:a2C4yPF27ApsiDb+4Zs/Y9zfwEmGv1gKwm/rlPYFE+w=
-github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55 h1:eTDTFWcvbFcwOmpFfgofgFJRRL2LLCngqbZj0Cjv0uU=
-github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55/go.mod h1:a2C4yPF27ApsiDb+4Zs/Y9zfwEmGv1gKwm/rlPYFE+w=
+github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c h1:dNb6Fp37X9YOnNl7EgHMRNOxvi5AEy1LR7gEtLkSfks=
+github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c/go.mod h1:a2C4yPF27ApsiDb+4Zs/Y9zfwEmGv1gKwm/rlPYFE+w=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1152,7 +1146,6 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.39.0 h1:Klz8I9kdtkIN6EpHHUOMLCYhTn/2WAe5a0s1hcBkdTI=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/google/trillian v1.3.14-0.20210409160123-c5ea3abd4a41/go.mod h1:1dPv0
 github.com/google/trillian v1.3.14-0.20210511103300-67b5f349eefa/go.mod h1:s4jO3Ai4NSvxucdvqUHON0bCqJyoya32eNw6XJwsmNc=
 github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb h1:yeHtIX6OICHMk4i8+mzZeYLcGXD5WvT4lfhhF/1MAaI=
 github.com/google/trillian v1.3.14-0.20210629100747-d06638f9d2fb/go.mod h1:Q959//o0gl8oMt92EQCmgoG1bgLmptrBT7ArV281XW0=
-github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c h1:dNb6Fp37X9YOnNl7EgHMRNOxvi5AEy1LR7gEtLkSfks=
-github.com/google/trillian-examples v0.0.0-20210630144057-5272a31d4a4c/go.mod h1:a2C4yPF27ApsiDb+4Zs/Y9zfwEmGv1gKwm/rlPYFE+w=
+github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55 h1:eTDTFWcvbFcwOmpFfgofgFJRRL2LLCngqbZj0Cjv0uU=
+github.com/google/trillian-examples v0.0.0-20210630165623-267fb50f0b55/go.mod h1:a2C4yPF27ApsiDb+4Zs/Y9zfwEmGv1gKwm/rlPYFE+w=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This monitor persists a checkpoint locally in order to maintain a consistent view of the log's history between runs. For each leaf:
 * The raw data is downloaded into memory
 * The leaf is verified to be included within the golden checkpoint
 * The leaf data is parsed as a note, and confirmed to be signed by the expected key
 * The note text is parsed as a FirmwareRelease
 * Some useful subset of data from the verified release is printed to the log

The monitor will detect new checkpoints by polling the log periodically.
Any error will cause the tool to fail; we may wish to make some failures print warnings/errors in the log instead.
On succesfully verifying all leaves up to a checkpoint size, the checkpoint is persisted locally so that the visited leaves will not be visited again.