### PR TITLE
Embed release pub key in action yaml

### DIFF
--- a/.github/workflows/leaves_pr.yaml
+++ b/.github/workflows/leaves_pr.yaml
@@ -30,4 +30,6 @@ jobs:
       id: signature_validator
       run: ${GITHUB_WORKSPACE}/.github/workflows/signature_validation.sh
       env:
-        FR_PUBKEY: ${{ secrets.FR_PUBKEY }}
+        # the actions triggered by a pull_request event do not have access to GH secrets,
+        # therefore we embed the public key here. This should match keys/armory-drive-test.pub
+        FR_PUBKEY: armory-drive-test+e0b83da5+ARFd7yMO7VQgK/N+KWETnS5O6dSqcTmTzQUXgQhJVVG0


### PR DESCRIPTION
The pubkey can not be specified as GH secret as it is non accessible in pull_request actions.