### PR TITLE
Rename checkpoint Ecosystem to Origin

### DIFF
--- a/.github/workflows/push_to_master.yaml
+++ b/.github/workflows/push_to_master.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: google/trillian-examples/serverless/deploy/github/log/sequence_and_integrate@master
       with:
         log_dir: './log'
-        ecosystem: 'ArmoryDrive Log v0'
+        origin: 'ArmoryDrive Log v0'
       env:
         SERVERLESS_LOG_PRIVATE_KEY: ${{ secrets.SERVERLESS_LOG_PRIVATE_KEY }}
         SERVERLESS_LOG_PUBLIC_KEY: ${{ secrets.SERVERLESS_LOG_PUBLIC_KEY }}

--- a/api/checkpoint.go
+++ b/api/checkpoint.go
@@ -22,14 +22,14 @@ import (
 	"strconv"
 )
 
-// EcosystemV0 is the Checkpoint ecosystem string for this usecase.
-const EcosystemV0 = "ArmoryDrive Log v0"
+// OriginV0 is the Checkpoint origin string for this log.
+// TODO: extract into flag
+const OriginV0 = "ArmoryDrive Log v0"
 
 // Checkpoint represents a minimal log checkpoint.
 type Checkpoint struct {
-	// Ecosystem is the ecosystem/version string.
-	// This will always be the EcosystemV0 string defined above.
-	Ecosystem string
+	// Origin is the unique identifier for the log issuing this checkpoint.
+	Origin string
 	// Size is the number of entries in the log at this checkpoint.
 	Size uint64
 	// Hash is the hash which commits to the contents of the entire log.
@@ -41,7 +41,7 @@ type Checkpoint struct {
 //
 // The supplied data is expected to begin with the following 3 lines of text,
 // each followed by a newline:
-//  - <ecosystem/version string>
+//  - <Origin string>
 //  - <decimal representation of log size>
 //  - <base64 representation of root hash>
 //
@@ -51,9 +51,10 @@ func (c *Checkpoint) Unmarshal(data []byte) error {
 	if len(l) < 4 {
 		return errors.New("invalid checkpoint - too few newlines")
 	}
-	eco := string(l[0])
-	if eco != EcosystemV0 {
-		return fmt.Errorf("invalid checkpoint - incorrect ecosystem %q", eco)
+	origin := string(l[0])
+	// TODO: extract this check elsewhere or pass in expected origin.
+	if origin != OriginV0 {
+		return fmt.Errorf("invalid checkpoint - incorrect origin %q", origin)
 	}
 	size, err := strconv.ParseUint(string(l[1]), 10, 64)
 	if err != nil {
@@ -67,9 +68,9 @@ func (c *Checkpoint) Unmarshal(data []byte) error {
 		return fmt.Errorf("invalid checkpoint - %d bytes of unexpected trailing data", xl)
 	}
 	*c = Checkpoint{
-		Ecosystem: eco,
-		Size:      size,
-		Hash:      h,
+		Origin: origin,
+		Size:   size,
+		Hash:   h,
 	}
 	return nil
 }

--- a/api/checkpoint_test.go
+++ b/api/checkpoint_test.go
@@ -31,9 +31,9 @@ func TestUnmarshalCheckpoint(t *testing.T) {
 			desc: "valid one",
 			m:    "ArmoryDrive Log v0\n123\nYmFuYW5hcw==\n",
 			want: Checkpoint{
-				Ecosystem: "ArmoryDrive Log v0",
-				Size:      123,
-				Hash:      []byte("bananas"),
+				Origin: "ArmoryDrive Log v0",
+				Size:   123,
+				Hash:   []byte("bananas"),
 			},
 		}, {
 			desc:    "wrong ecosystem",

--- a/api/verify/verify.go
+++ b/api/verify/verify.go
@@ -52,6 +52,7 @@ func Bundle(pb api.ProofBundle, oldCP api.Checkpoint, logSigV note.Verifier, frS
 		if err := newCP.Unmarshal([]byte(newCPRaw.Text)); err != nil {
 			return fmt.Errorf("failed to unmarshal NewCheckpoint: %v", err)
 		}
+		// TODO: verify newCP.Origin is as expected given logSigV.
 	}
 
 	if l := uint64(len(pb.LeafHashes)); l != newCP.Size {

--- a/api/verify/verify_test.go
+++ b/api/verify/verify_test.go
@@ -271,7 +271,7 @@ func makeFirmwareRelease(t *testing.T, artifacts map[string][]byte, sig note.Sig
 
 func makeCheckpoint(t *testing.T, size int, hash []byte, sig note.Signer) []byte {
 	t.Helper()
-	cp := fmt.Sprintf("%s\n%d\n%s\n", api.EcosystemV0, int64(size), base64.StdEncoding.EncodeToString(hash))
+	cp := fmt.Sprintf("%s\n%d\n%s\n", api.OriginV0, int64(size), base64.StdEncoding.EncodeToString(hash))
 	n, err := note.Sign(&note.Note{Text: cp}, sig)
 	if err != nil {
 		t.Fatalf("Failed to sign checkpoint: %v", err)


### PR DESCRIPTION
Migrate serverless log action configs and checkpoint code to follow upstream [format](https://github.com/google/trillian-examples/pull/470) and [parameter](https://github.com/google/trillian-examples/pull/472) changes.

This update reflects a small semantic change in the the first line of the checkpoint which now identifies the log making the claim - this is a preventative measure to avoid the possibility of witness cosignatures on a checkpoint from log A being considered valid for a byte-wise identical checkpoint from Log B.
