### PR TITLE
Updated the monitor to verify the reproducible builds.

### DIFF
--- a/cmd/monitor/Dockerfile
+++ b/cmd/monitor/Dockerfile
@@ -1,0 +1,54 @@
+# This Dockerfile builds an image with all the tools needed to
+# build armory-drive. The entrypoint will run a monitor that
+# reproduces the builds from the armory-drive-log.
+FROM golang:1.17-alpine AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/monitor ./cmd/monitor
+
+#
+# Set up the final image
+#
+FROM golang:1.17-buster
+
+RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get -y install curl unzip bzip2 wget xxd
+
+# Set up the proto compilation stuff
+RUN cd /usr && \
+    wget "https://github.com/google/protobuf/releases/download/v3.12.4/protoc-3.12.4-linux-x86_64.zip" && \
+    unzip "protoc-3.12.4-linux-x86_64.zip"
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27
+
+# Tamago bits
+RUN apt-get -y install binutils-arm-none-eabi
+# RUN curl -sfL https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | tar -xjf - -C /tmp/ && \
+#     cp -R /tmp/gcc-arm-none-eabi-10.3-2021.10/* /usr/
+
+RUN apt-get -y install bash git build-essential make u-boot-tools musl-tools && \
+    apt-get -y install -t buster-backports fuse fuse2fs
+RUN curl -sfL https://github.com/f-secure-foundry/tamago-go/releases/download/tamago-go1.17.1/tamago-go1.17.1.linux-amd64.tar.gz | tar -xzf - -C /
+ENV TAMAGO=/usr/local/tamago-go/bin/go
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/tamago-go/bin:/usr/local/go/bin:$PATH
+
+COPY --from=builder /build/bin/monitor /bin/monitor
+
+ENTRYPOINT ["/bin/monitor", "--alsologtostderr", "--state_file=/tmp/state"]

--- a/cmd/monitor/Dockerfile
+++ b/cmd/monitor/Dockerfile
@@ -38,6 +38,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27
 
 # Tamago bits
 RUN apt-get -y install binutils-arm-none-eabi
+# This installs a newer version of the cross-compilation tools, but they seem to behave the same.
 # RUN curl -sfL https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | tar -xjf - -C /tmp/ && \
 #     cp -R /tmp/gcc-arm-none-eabi-10.3-2021.10/* /usr/
 

--- a/cmd/monitor/Dockerfile
+++ b/cmd/monitor/Dockerfile
@@ -24,31 +24,24 @@ RUN go build -o /build/bin/monitor ./cmd/monitor
 #
 # Set up the final image
 #
-FROM golang:1.17-buster
+FROM ubuntu:18.04
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get -y install curl unzip bzip2 wget xxd
+RUN apt-get -y install curl unzip wget xxd git
+
+# Tamago bits
+RUN apt-get -y install binutils-arm-none-eabi build-essential make u-boot-tools musl-tools
+RUN curl -sfL https://github.com/f-secure-foundry/tamago-go/releases/download/tamago-go1.17.1/tamago-go1.17.1.linux-amd64.tar.gz | tar -xzf - -C /
+ENV TAMAGO=/usr/local/tamago-go/bin/go
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/tamago-go/bin:/usr/local/go/bin:$PATH
 
 # Set up the proto compilation stuff
 RUN cd /usr && \
     wget "https://github.com/google/protobuf/releases/download/v3.12.4/protoc-3.12.4-linux-x86_64.zip" && \
     unzip "protoc-3.12.4-linux-x86_64.zip"
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27
-
-# Tamago bits
-RUN apt-get -y install binutils-arm-none-eabi
-# This installs a newer version of the cross-compilation tools, but they seem to behave the same.
-# RUN curl -sfL https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | tar -xjf - -C /tmp/ && \
-#     cp -R /tmp/gcc-arm-none-eabi-10.3-2021.10/* /usr/
-
-RUN apt-get -y install bash git build-essential make u-boot-tools musl-tools && \
-    apt-get -y install -t buster-backports fuse fuse2fs
-RUN curl -sfL https://github.com/f-secure-foundry/tamago-go/releases/download/tamago-go1.17.1/tamago-go1.17.1.linux-amd64.tar.gz | tar -xzf - -C /
-ENV TAMAGO=/usr/local/tamago-go/bin/go
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/tamago-go/bin:/usr/local/go/bin:$PATH
 
 COPY --from=builder /build/bin/monitor /bin/monitor
 

--- a/cmd/monitor/README.md
+++ b/cmd/monitor/README.md
@@ -1,0 +1,33 @@
+# Reproducible Build Verifier
+
+This continuously monitors the log to look for claims about builds being published.
+The log properties are checked to ensure the log is consistent with any previous
+view, and that all claims are verifiably committed to by the log.
+
+For each [`FirmwareRelease`](https://github.com/f-secure-foundry/armory-drive-log/blob/master/api/log_entries.go#L26)
+manifest claim that it hasn't seen before, the following steps are taken:
+ 1. The source repository is cloned at the release tag
+ 2. The git revision at the tag is checked against the manifest
+ 3. The imx file is compiled from source
+ 4. The hash for the imx in the manifest is compared against the locally built version
+
+## Running
+
+In order to control the environment in which the code will be built,
+a Dockerfile is supplied which will create a compatible environment.
+
+This image can be built and executed using the following commands:
+
+```bash
+docker build . -t armory-drive-monitor -f ./cmd/monitor/Dockerfile
+docker run armory-drive-monitor -v=1
+```
+
+Note that it is expected that the first entry in the log is not reproducibly
+built. This is because of https://github.com/golang/go/issues/48557 which
+was fixed in https://github.com/f-secure-foundry/armory-drive/commit/f3a32e3ab3aac6866a3bd8b70a6575d87335ef5d.
+
+## TODO
+
+ * Support for toolchains other than tamago 1.17.1
+ * More visible reporting mechanisms than `glog` on success/failure

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -15,7 +15,10 @@
 // monitor starts a long-running process that will continually follow a log
 // for new checkpoints. All checkpoints are checked for consistency, and all
 // leaves in the tree will be downloaded, verified, and the release info
-// printed to the program's log (via `glog.Info`).
+// will be reproducibly verified.
+// This tool has a number of expectations of the environment, such as a working
+// tamago installation, git, and other make tooling. See the README and Dockerfile
+// in this directory for more details.
 package main
 
 import (

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/f-secure-foundry/armory-drive-log/api"
+	"github.com/f-secure-foundry/armory-drive-log/keys"
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
 	"github.com/google/trillian/merkle/rfc6962"
@@ -41,9 +42,9 @@ var (
 	pollInterval  = flag.Duration("poll_interval", 1*time.Minute, "The interval at which the log will be polled for new data")
 	stateFile     = flag.String("state_file", "", "File path for where checkpoints should be stored")
 	logURL        = flag.String("log_url", "https://raw.githubusercontent.com/f-secure-foundry/armory-drive-log/master/log/", "URL identifying the location of the log")
-	logPubKey     = flag.String("log_pubkey", "armory-drive-log+16541b8f+AYDPmG5pQp4Bgu0a1mr5uDZ196+t8lIVIfWQSPWmP+Jv", "The log's public key")
+	logPubKey     = flag.String("log_pubkey", keys.ArmoryDriveLogPub, "The log's public key")
 	logOrigin     = flag.String("log_origin", "Armory Drive Prod 2", "The expected first line of checkpoints issued by the log")
-	releasePubKey = flag.String("release_pubkey", "armory-drive+5a95a41b+Abfbe1W4+bZB//VfIXxds+SWldvUKRFxKHIy2fyg5nBO", "The release signer's public key")
+	releasePubKey = flag.String("release_pubkey", keys.ArmoryDrivePub, "The release signer's public key")
 	cleanup       = flag.Bool("cleanup", true, "Set to false to keep git checkouts and make artifacts around after verification")
 )
 

--- a/cmd/monitor/verify.go
+++ b/cmd/monitor/verify.go
@@ -77,6 +77,8 @@ func (v *ReproducibleBuildVerifier) VerifyManifest(ctx context.Context, i uint64
 		return fmt.Errorf("expected revision %q but got %q for tag %q", want, got, r.Revision)
 	}
 
+	// TODO: support downloading other TAMAGO compiler builds.
+	// For now, this just uses the one version pointed to by the process env.
 	tamagoBin := ""
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "TAMAGO=") {
@@ -111,14 +113,14 @@ func (v *ReproducibleBuildVerifier) VerifyManifest(ctx context.Context, i uint64
 		return fmt.Errorf("failed to make: %v (%s)", err, out)
 	}
 
-	// Hash the imx
-	data, err := ioutil.ReadFile(filepath.Join(repoRoot, "armory-drive.imx"))
+	// Hash the firmware artifact.
+	data, err := ioutil.ReadFile(filepath.Join(repoRoot, api.FirmwareArtifactName))
 	if err != nil {
-		return fmt.Errorf("failed to read armory-drive.imx: %v", err)
+		return fmt.Errorf("failed to read %s: %v", api.FirmwareArtifactName, err)
 	}
-	if got, want := sha256.Sum256(data), r.ArtifactSHA256["armory-drive.imx"]; !bytes.Equal(got[:], want) {
-		// TODO: this should return an error
-		glog.Errorf("Failed to verify armory-drive.imx build (got %x, wanted %x)", got, want)
+	if got, want := sha256.Sum256(data), r.ArtifactSHA256[api.FirmwareArtifactName]; !bytes.Equal(got[:], want) {
+		// TODO: report this in a more visible way than an error in the log.
+		glog.Errorf("Failed to verify %s build (got %x, wanted %x)", api.FirmwareArtifactName, got, want)
 	} else {
 		glog.Infof("Leaf %d for revision %q verified at git tag %q", i, r.Revision, r.BuildArgs["REV"])
 	}

--- a/cmd/monitor/verify.go
+++ b/cmd/monitor/verify.go
@@ -1,0 +1,127 @@
+// Copyright 2021 The Project Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/f-secure-foundry/armory-drive-log/api"
+	"github.com/f-secure-foundry/armory-drive-log/keys"
+	"github.com/golang/glog"
+)
+
+const (
+	gitOwner = "f-secure-foundry"
+	gitRepo  = "armory-drive"
+)
+
+func NewReproducibleBuildVerifier(cleanup bool) (*ReproducibleBuildVerifier, error) {
+	return &ReproducibleBuildVerifier{
+		cleanup: cleanup,
+	}, nil
+}
+
+type ReproducibleBuildVerifier struct {
+	cleanup bool
+}
+
+func (v *ReproducibleBuildVerifier) VerifyManifest(ctx context.Context, i uint64, r api.FirmwareRelease) error {
+	glog.V(1).Infof("VerifyManifest %d: %q", i, r.Revision)
+	// Create temporary directory that will be cleaned up after this method returns
+	dir, err := os.MkdirTemp("", "armory-verify")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	if v.cleanup {
+		defer os.RemoveAll(dir)
+	} else {
+		glog.Infof("Cleanup disabled: %q will not be deleted after use", dir)
+	}
+
+	glog.V(1).Infof("Cloning repo into %q", dir)
+	// Clone the repository at the release tag
+	cmd := exec.Command("/usr/bin/git", "clone", fmt.Sprintf("https://github.com/%s/%s", gitOwner, gitRepo), "-b", r.Revision)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to clone: %v (%s)", err, out)
+	}
+
+	repoRoot := filepath.Join(dir, gitRepo)
+	// Confirm that the git revision matches the manifest
+	cmd = exec.Command("/usr/bin/git", "rev-parse", "--short", "HEAD")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get HEAD revision: %v (%s)", err, out)
+	}
+	if got, want := strings.TrimSpace(string(out)), r.BuildArgs["REV"]; got != want {
+		return fmt.Errorf("expected revision %q but got %q for tag %q", want, got, r.Revision)
+	}
+
+	tamagoBin := ""
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "TAMAGO=") {
+			tamagoBin = e[len("TAMAGO="):]
+		}
+	}
+	if len(tamagoBin) == 0 {
+		return fmt.Errorf("failed to find TAMAGO in env")
+	}
+	out, err = exec.Command(tamagoBin, "version").Output()
+	if err != nil {
+		return fmt.Errorf("failed to get tamago version: %v (%s)", err, out)
+	}
+	if got, want := fmt.Sprintf("tama%s", strings.TrimSpace(string(out))), r.ToolChain; got != want {
+		return fmt.Errorf("expected toolchain %q but got %q for tag %q", want, got, r.Revision)
+	}
+
+	// Copy the public keys into place
+	otaDir := filepath.Join(repoRoot, "internal", "ota")
+	if err := os.WriteFile(filepath.Join(otaDir, "armory-drive-log.pub"), []byte(keys.ArmoryDriveLogPub), 0666); err != nil {
+		return fmt.Errorf("failed to write key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(otaDir, "armory-drive.pub"), []byte(keys.ArmoryDrivePub), 0666); err != nil {
+		return fmt.Errorf("failed to write key: %v", err)
+	}
+
+	// Make the imx file
+	glog.V(1).Infof("Running make in %s", repoRoot)
+	cmd = exec.Command("/usr/bin/make", "CROSS_COMPILE=arm-none-eabi-", "imx")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to make: %v (%s)", err, out)
+	}
+
+	// Hash the imx
+	data, err := ioutil.ReadFile(filepath.Join(repoRoot, "armory-drive.imx"))
+	if err != nil {
+		return fmt.Errorf("failed to read armory-drive.imx: %v", err)
+	}
+	if got, want := sha256.Sum256(data), r.ArtifactSHA256["armory-drive.imx"]; !bytes.Equal(got[:], want) {
+		// TODO: this should return an error
+		glog.Errorf("Failed to verify armory-drive.imx build (got %x, wanted %x)", got, want)
+	} else {
+		glog.Infof("Leaf %d for revision %q verified at git tag %q", i, r.Revision, r.BuildArgs["REV"])
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/trillian v1.3.14-0.20210902135231-6ff130e23e0c
 	github.com/google/trillian-examples v0.0.0-20210909165703-c62749b7931e
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/mod v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,9 @@ golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -958,6 +959,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,3 +1,18 @@
+// Copyright 2022 The Project Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keys exposes the public verification keys needed to verify log data.
 package keys
 
 import _ "embed"

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,0 +1,10 @@
+package keys
+
+import _ "embed"
+
+var (
+	//go:embed armory-drive-log.pub
+	ArmoryDriveLogPub string
+	//go:embed armory-drive.pub
+	ArmoryDrivePub string
+)


### PR DESCRIPTION
As the monitor requires an environment set up, a Dockerfile has been prepared to run this in. Instructions:

    ```bash
    docker build . -t armory-drive-monitor -f ./cmd/monitor/Dockerfile
    docker run armory-drive-monitor -v=1
    ```

Note that of the two builds in the log, this setup can only reproduce the build for the most recent one.

TODO: determine what part of the non-hermetic environment could have caused this.